### PR TITLE
v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 1.0.0
-
 * Implement WebColorPicker and WebColorPicker.builder widgets.
 
+## 1.0.3
+* Fix image display issue in README
+* Update pubspec.yaml with:
+    - the correct platform declaration syntax
+    - the correct screenshots links

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: web_color_picker
 description: This package allows you use the native web browser color picker in your Flutter Web app. 
-version: 1.0.0
+version: 1.0.3
 repository: https://github.com/victoreronmosele/flutter_web_color_picker
 issue_tracker: https://github.com/victoreronmosele/flutter_web_color_picker/issues
 


### PR DESCRIPTION
This release contains fixes for the following: 

- Image display issue in the `README.md` file.
- Platform declaration syntax in the `pubspec.yaml` file.
- Correct screenshot links in the `pubspec.yaml` file.

The package's homepage, https://pub.dev/packages/web_color_picker now displays all information correctly. 