### PR TITLE
Export Event object

### DIFF
--- a/lib/web_color_picker.dart
+++ b/lib/web_color_picker.dart
@@ -12,6 +12,8 @@ import 'package:web_color_picker/src/util.dart';
 import 'package:uuid/uuid.dart';
 import 'package:universal_html/html.dart' as html;
 
+export 'package:universal_html/html.dart' show Event;
+
 /// The default border box dimension of the color input element as rendered by
 /// Chrome and Edge.
 ///


### PR DESCRIPTION
This PR exports the `Event` object so that users of the library that do not have to import the `Event` from `dart:html` to use the callbacks. 

