### PR TITLE
v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 * Implement WebColorPicker and WebColorPicker.builder widgets.
 
 ## 1.0.3
-* Fix image display issue in README
+* Fix image display issue in README.
 * Update pubspec.yaml with:
-    - the correct platform declaration syntax
-    - the correct screenshots links
+    - the correct platform declaration syntax.
+    - the correct screenshots links.
+
+## 1.0.4
+* Export the Event object.

--- a/lib/web_color_picker.dart
+++ b/lib/web_color_picker.dart
@@ -12,6 +12,8 @@ import 'package:web_color_picker/src/util.dart';
 import 'package:uuid/uuid.dart';
 import 'package:universal_html/html.dart' as html;
 
+export 'package:universal_html/html.dart' show Event;
+
 /// The default border box dimension of the color input element as rendered by
 /// Chrome and Edge.
 ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: web_color_picker
 description: This package allows you use the native web browser color picker in your Flutter Web app. 
-version: 1.0.3
+version: 1.0.4
 repository: https://github.com/victoreronmosele/flutter_web_color_picker
 issue_tracker: https://github.com/victoreronmosele/flutter_web_color_picker/issues
 


### PR DESCRIPTION
This release exports the `Event` object so that users of the library that do not have to import the `Event` from `dart:html` to use the callbacks.